### PR TITLE
v2.0.1: publish the .Api library to NuGet instead of the console exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-04-16
+
+### Fixed
+- The NuGet package now publishes the `Corsinvest.ProxmoxVE.NodeProtect.Api` library instead of the console executable, so other projects can depend on the backup engine as a library
+
 ## [2.0.0] - 2026-04-15
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Project>
     <PropertyGroup>
-        <Version>2.0.0</Version>
+        <Version>2.0.1</Version>
         <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/packaging/config
+++ b/packaging/config
@@ -4,5 +4,5 @@ long-description=Backup Proxmox VE node configuration files via SSH.
 license=GPL-3.0-only
 winget-id=Corsinvest.cv4pve.nodeprotect
 pkg-identifier=it.corsinvest.cv4pve-node-protect
-nuget-project-path=src/Corsinvest.ProxmoxVE.NodeProtect/Corsinvest.ProxmoxVE.NodeProtect.csproj
+nuget-project-path=src/Corsinvest.ProxmoxVE.NodeProtect.Api/Corsinvest.ProxmoxVE.NodeProtect.Api.csproj
 homebrew-formula-class=Cv4pveNodeProtect


### PR DESCRIPTION
## Summary

Fix the NuGet package published by the release workflow:

- **v2.0.0 published the wrong project** — the console executable (`cv4pve-node-protect`) was pushed to nuget.org as the package. The intended NuGet package is the `Corsinvest.ProxmoxVE.NodeProtect.Api` library, so other projects (e.g. cv4pve-admin) can reference the backup engine.
- **Fix**: `nuget-project-path` in `packaging/config` now points to the `.Api` project, matching the convention used in `cv4pve-autosnap` and `cv4pve-diag`.
- **Version bumped** to 2.0.1 — no user-facing changes, just a packaging fix.

## Follow-up (manual)

After merge + tag `v2.0.1`:
- Unlist the broken `cv4pve-node-protect` 2.0.0 package on nuget.org (NuGet doesn't allow deletion)

## Test plan

- [ ] Publish workflow pushes `Corsinvest.ProxmoxVE.NodeProtect.Api` 2.0.1 to nuget.org
- [ ] WinGet install still works (`winget install Corsinvest.cv4pve.nodeprotect`)