### PR TITLE
v2.1.0: IPv6 host support, stream-based backup, new ToStream API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.1] - 2026-04-16
+## [2.1.0] - 2026-04-17
+
+### Added
+- **IPv6 support** in `--host` — you can now target nodes by IPv6 address. Use brackets if you also specify a port: `[fe80::1]:2222`. Without a port, brackets are optional: `fe80::1`
+
+### Changed
+- **Backup no longer uses temporary files on the node** — the archive is streamed directly from the Proxmox node into your local file. Nothing is written to `/tmp` on the node, so crashes or interrupted runs don't leave leftover files behind
+- Hosts, paths and SSH ports that contain unusual characters are now handled safely
+- Console output is shorter and easier to read: "Create config" and "Delete Backup" show the folder name instead of the full path
 
 ### Fixed
 - The NuGet package now publishes the `Corsinvest.ProxmoxVE.NodeProtect.Api` library instead of the console executable, so other projects can depend on the backup engine as a library

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Project>
     <PropertyGroup>
-        <Version>2.0.1</Version>
+        <Version>2.1.0</Version>
         <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.14" />
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.14" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.15" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.15" />
     <PackageVersion Include="SSH.NET" Version="2025.1.0" />
   </ItemGroup>
 </Project>

--- a/README.MD
+++ b/README.MD
@@ -85,7 +85,8 @@ cv4pve-node-protect @config.rsp backup --directory-work=/backup --paths="/etc/."
 - **Selective paths** — choose exactly what to archive with `--paths` (semicolon separated)
 - **Retention** — `--keep=N` automatically prunes older backup folders
 - **Multiple auth** — password, password from file, or SSH private key (with optional passphrase)
-- **Custom SSH port** — per host: `host:port,host2:port`
+- **Custom SSH port** — per host: `host:port,host2:port` (IPv6 addresses use brackets: `[::1]:2222`)
+- **IPv6 support** — IPv4, IPv6 and hostname all accepted
 - **Timestamp folders** — backups organized as `YYYY-MM-DD-HH-mm-ss/{host}-config.tar.gz`
 - **Agentless** — only SSH required on the target nodes, no software installed
 - **Cross-platform** — Windows, Linux, macOS — native single binary
@@ -126,12 +127,19 @@ The tool uses **plain SSH** — it does not use the Proxmox API. Any Linux user 
 
 ### Host Syntax
 
+Comma-separated list of hosts. Each entry is `host[:port]`. Default port is `22`.
+
 ```
 --host=host1                              # single host, default port 22
 --host=host1:2222                         # single host, custom port
---host=192.168.1.100,192.168.1.101        # multiple hosts
+--host=192.168.1.100,192.168.1.101        # multiple hosts (IPv4)
 --host=host1:2222,host2:2222              # multiple hosts, custom ports
+--host=fe80::1                            # single IPv6 address, default port
+--host=[fe80::1]:2222                     # IPv6 with custom port (brackets required)
+--host=[::1]:22,pve01,192.168.1.10        # mix IPv6, hostname and IPv4
 ```
+
+**IPv6 note**: when specifying a port with an IPv6 address, the address **must** be enclosed in square brackets to disambiguate the `:` used as port separator from the `:` inside the address (same convention as URLs, e.g. `http://[::1]:8080`). Without a port, brackets are optional.
 
 </details>
 
@@ -155,7 +163,7 @@ cv4pve-node-protect [global-options] backup [backup-options]
 
 | Option | Description |
 |--------|-------------|
-| `--host` | Target host(s): `host[:port],host2[:port],…` |
+| `--host` | Target host(s): `host[:port],host2[:port],…` (IPv4, IPv6 in brackets `[::1]:22`, or hostname) |
 | `--username` | SSH username |
 | `--password` | SSH password or `file:/path` |
 | `--private-key-file` | Path to SSH private key |

--- a/src/Corsinvest.ProxmoxVE.NodeProtect.Api/ProtectEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.NodeProtect.Api/ProtectEngine.cs
@@ -4,43 +4,27 @@
  */
 
 using System.Diagnostics;
-using System.Text;
-using System.Text.RegularExpressions;
-using Corsinvest.ProxmoxVE.Api.Shared;
 using Microsoft.Extensions.Logging;
 using Renci.SshNet;
 
 namespace Corsinvest.ProxmoxVE.NodeProtect.Api;
 
 /// <summary>
-/// Node protect
+/// Backs up configuration from a single Proxmox VE node via SSH.
+/// The tar.gz archive is streamed over the SSH channel directly into the caller's
+/// target file — no temporary files are created on the node.
 /// </summary>
-public class ProtectEngine(string hostsAndPort,
-                           string username,
-                           string password,
-                           string passphrase,
-                           string privateKeyFile,
-                           int? timeout)
+public class ProtectEngine(ILogger<ProtectEngine> logger)
 {
     /// <summary>
-    /// Date format directory
+    /// Default suffix for the tar.gz file produced for a node.
     /// </summary>
-    public static readonly string FORMAT_DATE = "yyyy-MM-dd-HH-mm-ss";
+    public const string FileNameSuffix = "-config.tar.gz";
 
-    private const string FILE_NAME = "-config.tar.gz";
-
-    private static readonly Regex DateFolderRegex = new(@"^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$", RegexOptions.Compiled);
-
-    private static (string Host, int Port) ParseHostAndPort(string hostAndPort)
-    {
-        var data = hostAndPort.Split(':');
-        var host = data[0];
-        var port = data.Length == 2
-                        ? int.TryParse(data[1], out var result2) ? result2 : 22
-                        : 22;
-
-        return (host, port);
-    }
+    /// <summary>
+    /// Date format used by conventional callers for timestamped backup directories.
+    /// </summary>
+    public const string DateFormat = "yyyy-MM-dd-HH-mm-ss";
 
     private static string ShellQuote(string value)
     {
@@ -52,173 +36,87 @@ public class ProtectEngine(string hostsAndPort,
     }
 
     /// <summary>
-    /// Backup
+    /// Streams a tar.gz of the given paths from the node into <paramref name="targetFilePath"/>.
+    /// Nothing is written to the node's filesystem.
     /// </summary>
-    public async Task BackupAsync(string[] pathsToBackup,
-                                  string directoryWork,
-                                  int keep,
-                                  TextWriter @out,
-                                  ILoggerFactory loggerFactory)
+    /// <param name="node">Host name shown in logs (informational).</param>
+    /// <param name="connectionInfo">SSH connection info with auth already configured by the caller.</param>
+    /// <param name="paths">Absolute paths on the node to include in the archive.</param>
+    /// <param name="targetFilePath">Local destination file. Parent directory must exist.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Human-readable operation summary.</returns>
+    public async Task<string> BackupNodeAsync(string node,
+                                              ConnectionInfo connectionInfo,
+                                              IEnumerable<string> paths,
+                                              string targetFilePath,
+                                              CancellationToken cancellationToken = default)
     {
-        var logger = loggerFactory.CreateLogger<ProtectEngine>();
+        ArgumentException.ThrowIfNullOrEmpty(targetFilePath);
 
-        @out.WriteLine($@"ACTION Backup
-Keep: {keep}
-Directory Work: {directoryWork}
-Directory Node to archive:");
-
-        foreach (var item in pathsToBackup) { @out.WriteLine(item); }
-
-        var date = DateTime.Now;
-
-        //create folder date
-        var pathSave = Path.Combine(directoryWork, date.ToString(FORMAT_DATE));
-        Directory.CreateDirectory(pathSave);
-
-        foreach (var hostAndPort in hostsAndPort.Split(','))
+        try
         {
-            var (host, port) = ParseHostAndPort(hostAndPort);
-
-            var ret = await BackupAsync(host, port, pathsToBackup, logger);
-            var fileToSave = Path.Combine(pathSave, $"{host}{FILE_NAME}");
-
-            await using (var fileStream = File.Create(fileToSave))
-                await ret.Stream.CopyToAsync(fileStream);
-
-            @out.WriteLine($"Create config: {fileToSave}");
+            await using var fileStream = File.Create(targetFilePath);
+            return await BackupNodeToStreamAsync(node, connectionInfo, paths, fileStream, cancellationToken);
         }
-
-        //keep: only prune directories whose name matches the timestamp format
-        foreach (var item in Directory.GetDirectories(directoryWork)
-                                      .Where(d => DateFolderRegex.IsMatch(Path.GetFileName(d)))
-                                      .OrderByDescending(a => a)
-                                      .Skip(keep))
+        catch
         {
-            @out.WriteLine($"Delete Backup: {item}");
-            Directory.Delete(item, true);
-        }
-    }
-
-    private ConnectionInfo GetConnectionInfo(string node, int port)
-    {
-        var connectionInfo = new ConnectionInfo(node, port, username, GetAuthMethod());
-        if (timeout.HasValue) { connectionInfo.Timeout = TimeSpan.FromSeconds(timeout.Value); }
-        return connectionInfo;
-    }
-
-    private AuthenticationMethod GetAuthMethod()
-    {
-        if (string.IsNullOrEmpty(username))
-        {
-            throw new PveException("Username is required!");
-        }
-
-        if (!string.IsNullOrEmpty(privateKeyFile))
-        {
-            var keyFile = string.IsNullOrEmpty(passphrase)
-                            ? new PrivateKeyFile(privateKeyFile)
-                            : new PrivateKeyFile(privateKeyFile, passphrase);
-            return new PrivateKeyAuthenticationMethod(username, keyFile);
-        }
-        else if (!string.IsNullOrEmpty(password))
-        {
-            return new PasswordAuthenticationMethod(username, password);
-        }
-        else
-        {
-            throw new PveException("Invalid authentication!");
+            DeleteIfExists(targetFilePath);
+            throw;
         }
     }
 
     /// <summary>
-    /// Backup to stream
+    /// Streams a tar.gz of the given paths from the node into <paramref name="destination"/>.
+    /// Nothing is written to the node's filesystem nor to the local disk — the caller owns the stream.
     /// </summary>
-    public async Task<(string Logs, Stream Stream)> BackupAsync(string node,
-                                                                int port,
-                                                                IEnumerable<string> paths,
-                                                                ILogger logger)
+    /// <param name="node">Host name shown in logs (informational).</param>
+    /// <param name="connectionInfo">SSH connection info with auth already configured by the caller.</param>
+    /// <param name="paths">Absolute paths on the node to include in the archive.</param>
+    /// <param name="destination">Destination stream. Not disposed by this method.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Human-readable operation summary.</returns>
+    public async Task<string> BackupNodeToStreamAsync(string node,
+                                                      ConnectionInfo connectionInfo,
+                                                      IEnumerable<string> paths,
+                                                      Stream destination,
+                                                      CancellationToken cancellationToken = default)
     {
-        var totalSw = Stopwatch.StartNew();
-        var stream = new MemoryStream();
-        var logs = new StringBuilder();
+        ArgumentNullException.ThrowIfNull(connectionInfo);
+        ArgumentNullException.ThrowIfNull(paths);
+        ArgumentNullException.ThrowIfNull(destination);
 
-        using var sshClient = new SshClient(GetConnectionInfo(node, port));
-        await sshClient.ConnectAsync(CancellationToken.None);
+        var sw = Stopwatch.StartNew();
 
-        async Task<(string StdOut, int ExitCode, string StdErr)> execCmdAsync(string command)
+        using var sshClient = new SshClient(connectionInfo);
+        await sshClient.ConnectAsync(cancellationToken);
+
+        var quotedPaths = string.Join(" ", paths.Select(ShellQuote));
+        // -f - streams the archive to stdout so we can pipe it over SSH without touching disk on the node
+        using var cmd = sshClient.CreateCommand($"tar --one-file-system -czPf - {quotedPaths}");
+
+        logger.LogDebug("[{Node}] Executing: {Cmd}", node, cmd.CommandText);
+
+        var asyncResult = cmd.BeginExecute();
+        await cmd.OutputStream.CopyToAsync(destination, cancellationToken);
+        cmd.EndExecute(asyncResult);
+
+        // tar exit: 0 ok, 1 = some files differed/changed during read (non-fatal, common on live FS),
+        // >=2 = real error
+        if (cmd.ExitStatus >= 2)
         {
-            using var c = sshClient.CreateCommand(command);
-            await c.ExecuteAsync();
-            return (c.Result, c.ExitStatus ?? -1, c.Error);
+            throw new InvalidOperationException($"[{node}] tar failed (exit {cmd.ExitStatus}): {cmd.Error}");
         }
 
-        // Create a random, non-predictable temp file on the remote node
-        var mkTempRet = await execCmdAsync("mktemp /tmp/cv4pve-node-protect-XXXXXXXX.tar.gz");
-        if (mkTempRet.ExitCode != 0 || string.IsNullOrWhiteSpace(mkTempRet.StdOut))
-        {
-            sshClient.Disconnect();
-            throw new PveException($"[{node}] Cannot create temp file: {mkTempRet.StdErr}");
-        }
-        var remoteTarGz = mkTempRet.StdOut.Trim();
+        sw.Stop();
+        logger.LogDebug("[{Node}] Backup streamed in {TotalSeconds:F2} seconds", node, sw.Elapsed.TotalSeconds);
 
-        try
-        {
-            // Restrict permissions before writing sensitive config
-            await execCmdAsync($"chmod 600 {ShellQuote(remoteTarGz)}");
+        return $"[{node}] tar.gz streamed in {sw.Elapsed.TotalSeconds:F2} sec";
+    }
 
-            // Create tar.gz
-            var sw = Stopwatch.StartNew();
-            logs.AppendLine($"[{node}] Create file tar.gz: {remoteTarGz}");
-
-            var quotedPaths = string.Join(" ", paths.Select(ShellQuote));
-            var cmd = $"tar --one-file-system -cvzPf {ShellQuote(remoteTarGz)} {quotedPaths}";
-            var ret = await execCmdAsync(cmd);
-            sw.Stop();
-
-            logger.LogDebug("Create tar.gz: {Cmd}", cmd);
-            logger.LogDebug("Result: {ExitCode}, Time: {Time}ms", ret.ExitCode, sw.ElapsedMilliseconds);
-
-            logs.Append(ret.StdOut);
-            logs.AppendLine($"[{node}] Created tar.gz in {sw.Elapsed.TotalSeconds:F2} sec");
-
-            // Download file
-            sw.Restart();
-            using (var sftpClient = new SftpClient(GetConnectionInfo(node, port)))
-            {
-                await sftpClient.ConnectAsync(CancellationToken.None);
-                try
-                {
-                    await sftpClient.DownloadFileAsync(remoteTarGz, stream);
-                    stream.Position = 0;
-                }
-                finally
-                {
-                    sftpClient.Disconnect();
-                }
-            }
-            sw.Stop();
-            logs.AppendLine($"[{node}] Downloaded tar.gz in {sw.Elapsed.TotalSeconds:F2} sec");
-        }
-        finally
-        {
-            // Always try to remove remote temp file, even on failure
-            try
-            {
-                var rmRet = await execCmdAsync($"rm -f {ShellQuote(remoteTarGz)}");
-                logger.LogDebug("Delete tar.gz: Result {ExitCode}", rmRet.ExitCode);
-                logs.AppendLine($"[{node}] Deleted remote tar.gz");
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning(ex, "Failed to delete remote file {Remote}", remoteTarGz);
-            }
-
-            sshClient.Disconnect();
-        }
-
-        totalSw.Stop();
-        logger.LogDebug("Backup completed in {TotalSeconds:F2} seconds", totalSw.Elapsed.TotalSeconds);
-
-        return (logs.ToString(), stream);
+    private void DeleteIfExists(string path)
+    {
+        if (!File.Exists(path)) { return; }
+        try { File.Delete(path); }
+        catch (Exception ex) { logger.LogWarning(ex, "Failed to delete partial local file {Path}", path); }
     }
 }

--- a/src/Corsinvest.ProxmoxVE.NodeProtect/Program.cs
+++ b/src/Corsinvest.ProxmoxVE.NodeProtect/Program.cs
@@ -4,89 +4,208 @@
  */
 
 using System.CommandLine;
+using System.Text.RegularExpressions;
 using Corsinvest.ProxmoxVE.Api.Console.Helpers;
 using Corsinvest.ProxmoxVE.NodeProtect.Api;
 using Microsoft.Extensions.Logging;
+using Renci.SshNet;
 
-var app = new RootCommand("Node protect for Proxmox VE");
-app.AddFullNameLogo();
-app.AddDebugOption();
-app.AddLogLevelOption();
-
-var optUsername = app.AddOption<string>("--username", "User name");
-var optPassword = app.AddOption<string>("--password", "Password, or 'file:/path/to/file' to read from file");
-optPassword.Required = false;
-
-var optPrivateKeyFile = app.AddOption<string>("--private-key-file", "Private key file")
-                           .AddValidatorExistFile();
-
-var optPassphrase = app.AddOption<string>("--passphrase", "Passphrase for private key file");
-
-var optHost = new Option<string>("--host")
+internal partial class Program
 {
-    Description = "The host name host[:port],host1[:port],host2[:port]",
-    Required = true,
-    CustomParser = (e) => e.Tokens.Single().Value
-};
+    [GeneratedRegex(@"^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$")]
+    private static partial Regex DateFolderRegex();
 
-app.Add(optHost);
-
-var optTimeout = app.AddOption<int?>("--timeout", "Timeout in seconds for ssh connection");
-
-var loggerFactory = ConsoleHelper.CreateLoggerFactory<Program>(app.GetLogLevelFromDebug());
-
-var cmdBackup = app.AddCommand("backup", "Backup configuration from nodes using ssh");
-var optKeep = cmdBackup.AddOption<int>("--keep", "Specify the number of backups to retain")
-                       .AddValidatorRange(1, 100);
-optKeep.Required = true;
-
-var optPathBackup = cmdBackup.AddOption<string>("--paths", "Paths to backup ';' separated");
-optPathBackup.Required = true;
-
-var optDirectoryWorkBackup = cmdBackup.AddOption<string>("--directory-work", "Directory work")
-                                      .AddValidatorExistDirectory();
-optDirectoryWorkBackup.Required = true;
-
-cmdBackup.SetAction(async (action) => await GetEngine(action)
-                                             .BackupAsync(action.GetValue(optPathBackup)!.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
-                                                          action.GetValue(optDirectoryWorkBackup)!,
-                                                          action.GetValue(optKeep)!,
-                                                          Console.Out,
-                                                          loggerFactory));
-
-ProtectEngine GetEngine(ParseResult action)
-{
-    var username = action.GetValue(optUsername);
-    var password = action.GetValue(optPassword);
-    var privateKeyFile = action.GetValue(optPrivateKeyFile);
-
-    if (string.IsNullOrEmpty(privateKeyFile) && string.IsNullOrEmpty(username))
+    private static async Task<int> Main(string[] args)
     {
-        throw new InvalidOperationException("Option '--username' or '--private-key-file' is required!");
-    }
+        var app = new RootCommand("Node protect for Proxmox VE");
+        app.AddFullNameLogo();
+        app.AddDebugOption();
+        app.AddLogLevelOption();
 
-    if (!string.IsNullOrEmpty(username) && string.IsNullOrEmpty(privateKeyFile) && string.IsNullOrEmpty(password))
-    {
-        throw new InvalidOperationException("Option '--password' is required when using '--username' without a private key!");
-    }
+        var optUsername = app.AddOption<string>("--username", "User name");
+        var optPassword = app.AddOption<string>("--password", "Password, or 'file:/path/to/file' to read from file");
+        optPassword.Required = false;
 
-    // Support '--password=file:/path/to/file'
-    if (!string.IsNullOrEmpty(password) && password.StartsWith("file:", StringComparison.Ordinal))
-    {
-        var path = password["file:".Length..];
-        if (!File.Exists(path))
+        var optPrivateKeyFile = app.AddOption<string>("--private-key-file", "Private key file")
+                                   .AddValidatorExistFile();
+
+        var optPassphrase = app.AddOption<string>("--passphrase", "Passphrase for private key file");
+
+        var optHost = new Option<string>("--host")
         {
-            throw new FileNotFoundException($"Password file not found: {path}", path);
+            Description = "Comma-separated list of hosts. Each entry is host[:port]. "
+                        + "Supported formats: hostname, IPv4 (192.168.0.1), IPv6 in brackets ([fe80::1]), "
+                        + "bare IPv6 without port (fe80::1). Default port is 22. "
+                        + "Examples: 'pve01,pve02', '192.168.0.1:2222', '[::1]:22,pve01'.",
+            Required = true,
+            CustomParser = (e) => e.Tokens.Single().Value
+        };
+
+        app.Add(optHost);
+
+        var optTimeout = app.AddOption<int?>("--timeout", "Timeout in seconds for ssh connection");
+
+        var loggerFactory = ConsoleHelper.CreateLoggerFactory<Program>(app.GetLogLevelFromDebug());
+
+        var cmdBackup = app.AddCommand("backup", "Backup configuration from nodes using ssh");
+        var optKeep = cmdBackup.AddOption<int>("--keep", "Specify the number of backups to retain")
+                               .AddValidatorRange(1, 100);
+        optKeep.Required = true;
+
+        var optPathBackup = cmdBackup.AddOption<string>("--paths", "Paths to backup ';' separated");
+        optPathBackup.Required = true;
+
+        var optDirectoryWorkBackup = cmdBackup.AddOption<string>("--directory-work", "Directory work")
+                                              .AddValidatorExistDirectory();
+        optDirectoryWorkBackup.Required = true;
+
+        cmdBackup.SetAction(async (action) => await RunBackupAsync(action));
+
+        return await app.ExecuteAppAsync(args, loggerFactory.CreateLogger<Program>());
+
+        async Task RunBackupAsync(ParseResult action)
+        {
+            var username = action.GetValue(optUsername);
+            var password = ResolvePassword(action.GetValue(optPassword));
+            var privateKeyFile = action.GetValue(optPrivateKeyFile);
+            var passphrase = action.GetValue(optPassphrase);
+            var timeout = action.GetValue(optTimeout);
+            var hostsAndPort = action.GetValue(optHost)!;
+            var paths = action.GetValue(optPathBackup)!.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var directoryWork = action.GetValue(optDirectoryWorkBackup)!;
+            var keep = action.GetValue(optKeep);
+
+            ValidateAuth(username, password, privateKeyFile);
+
+            var engine = new ProtectEngine(loggerFactory.CreateLogger<ProtectEngine>());
+
+            var @out = Console.Out;
+            @out.WriteLine($@"ACTION Backup
+Keep: {keep}
+Directory Work: {directoryWork}
+Directory Node to archive:");
+            foreach (var p in paths) { @out.WriteLine(p); }
+
+            // Create timestamped directory for this run
+            var pathSave = Path.Combine(directoryWork, DateTime.Now.ToString(ProtectEngine.DateFormat));
+            Directory.CreateDirectory(pathSave);
+
+            // Backup each host
+            foreach (var hostAndPort in hostsAndPort.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var (host, port) = ParseHostAndPort(hostAndPort);
+                var targetFile = Path.Combine(pathSave, $"{host}{ProtectEngine.FileNameSuffix}");
+                var connectionInfo = BuildConnectionInfo(host, port, username!, password, passphrase, privateKeyFile, timeout);
+
+                await engine.BackupNodeAsync(host, connectionInfo, paths, targetFile);
+                @out.WriteLine($"Create config: {Path.GetRelativePath(directoryWork, targetFile)}");
+            }
+
+            // Retention: keep only the latest N timestamped directories
+            foreach (var item in Directory.GetDirectories(directoryWork)
+                                          .Where(d => DateFolderRegex().IsMatch(Path.GetFileName(d)))
+                                          .OrderByDescending(a => a)
+                                          .Skip(keep))
+            {
+                @out.WriteLine($"Delete Backup: {Path.GetFileName(item)}");
+                Directory.Delete(item, true);
+            }
         }
-        password = File.ReadAllText(path).Trim();
+
+        static string? ResolvePassword(string? password)
+        {
+            if (string.IsNullOrEmpty(password)) { return password; }
+            if (!password.StartsWith("file:", StringComparison.Ordinal)) { return password; }
+
+            var path = password["file:".Length..];
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException($"Password file not found: {path}", path);
+            }
+            return File.ReadAllText(path).Trim();
+        }
+
+        static void ValidateAuth(string? username, string? password, string? privateKeyFile)
+        {
+            if (string.IsNullOrEmpty(privateKeyFile) && string.IsNullOrEmpty(username))
+            {
+                throw new InvalidOperationException("Option '--username' or '--private-key-file' is required!");
+            }
+
+            if (!string.IsNullOrEmpty(username) && string.IsNullOrEmpty(privateKeyFile) && string.IsNullOrEmpty(password))
+            {
+                throw new InvalidOperationException("Option '--password' is required when using '--username' without a private key!");
+            }
+        }
+
+        static (string Host, int Port) ParseHostAndPort(string hostAndPort)
+        {
+            const int DefaultPort = 22;
+
+            // IPv6 in brackets: [addr] or [addr]:port (canonical "host:port" notation for IPv6)
+            if (hostAndPort.StartsWith('['))
+            {
+                var closeBracket = hostAndPort.IndexOf(']');
+                if (closeBracket < 0) { throw new ArgumentException($"Invalid IPv6 format, missing ']': {hostAndPort}"); }
+
+                var hostV6 = hostAndPort[1..closeBracket];
+                var rest = hostAndPort[(closeBracket + 1)..];
+
+                if (rest.Length == 0) { return (hostV6, DefaultPort); }
+                if (!rest.StartsWith(':') || !int.TryParse(rest[1..], out var portV6))
+                {
+                    throw new ArgumentException($"Invalid port after ']' in: {hostAndPort}");
+                }
+                return (hostV6, portV6);
+            }
+
+            // IPv6 without brackets (e.g. "fe80::1"): more than one ':' → treat whole string as host, default port
+            if (hostAndPort.Count(c => c == ':') > 1) { return (hostAndPort, DefaultPort); }
+
+            // IPv4 or hostname, optionally with single ":port"
+            var parts = hostAndPort.Split(':');
+            var port = parts.Length == 2 && int.TryParse(parts[1], out var p) ? p : DefaultPort;
+            return (parts[0], port);
+        }
+
+        static ConnectionInfo BuildConnectionInfo(string host,
+                                                  int port,
+                                                  string username,
+                                                  string? password,
+                                                  string? passphrase,
+                                                  string? privateKeyFile,
+                                                  int? timeoutSeconds)
+        {
+            var authMethod = BuildAuthMethod(username, password, passphrase, privateKeyFile);
+            var connectionInfo = new ConnectionInfo(host, port, username, authMethod);
+            if (timeoutSeconds.HasValue) { connectionInfo.Timeout = TimeSpan.FromSeconds(timeoutSeconds.Value); }
+            return connectionInfo;
+        }
+
+        static AuthenticationMethod BuildAuthMethod(string username,
+                                                    string? password,
+                                                    string? passphrase,
+                                                    string? privateKeyFile)
+        {
+            if (string.IsNullOrEmpty(username))
+            {
+                throw new InvalidOperationException("Username is required!");
+            }
+
+            if (!string.IsNullOrEmpty(privateKeyFile))
+            {
+                var keyFile = string.IsNullOrEmpty(passphrase)
+                                ? new PrivateKeyFile(privateKeyFile)
+                                : new PrivateKeyFile(privateKeyFile, passphrase);
+                return new PrivateKeyAuthenticationMethod(username, keyFile);
+            }
+
+            if (!string.IsNullOrEmpty(password))
+            {
+                return new PasswordAuthenticationMethod(username, password);
+            }
+
+            throw new InvalidOperationException("Invalid authentication!");
+        }
     }
-
-    return new ProtectEngine(action.GetValue(optHost)!,
-                             username!,
-                             password!,
-                             action.GetValue(optPassphrase)!,
-                             privateKeyFile!,
-                             action.GetValue(optTimeout));
 }
-
-return await app.ExecuteAppAsync(args, loggerFactory.CreateLogger<Program>());


### PR DESCRIPTION
## Summary
- **IPv6 support** in `--host`: bracket notation `[addr]:port` or bare IPv6 without port
- **Stream-based backup**: `tar.gz` is now streamed directly from the node into the local file — no temporary file on `/tmp` of the remote
- **New `BackupNodeToStreamAsync` API**: lets library consumers pipe the archive into extraction, storage or any `Stream` without touching the local disk
- Safer shell quoting for hosts/paths/ports with unusual characters
- Shorter console output (folder name instead of full path)
- `Program` refactored to classic `Main` + `partial class` using `[GeneratedRegex]` for retention-filter matching

## Test plan
- [ ] `dotnet build -c Release` produces `Corsinvest.ProxmoxVE.NodeProtect.Api.2.1.0.nupkg`
- [ ] Console backup against IPv4 host still works
- [ ] Console backup against IPv6 host `[fe80::1]:2222` works
- [ ] After a run, no leftover `.tar.gz` exists on the Proxmox node's `/tmp`
- [ ] Retention (`--keep N`) deletes only timestamped folders, not unrelated ones