### PR TITLE
v2.1.1: tolerate missing paths with --ignore-failed-read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-04-20
+
+### Changed
+- **Backup no longer fails when a listed path is missing on the node** — tar now runs with `--ignore-failed-read`, so optional paths (like `/root/scripts` or `/var/lib/ceph/.` on nodes without Ceph) are silently skipped instead of aborting the whole run
+
 ## [2.1.0] - 2026-04-17
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Project>
     <PropertyGroup>
-        <Version>2.1.0</Version>
+        <Version>2.1.1</Version>
         <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>

--- a/README.MD
+++ b/README.MD
@@ -199,6 +199,9 @@ After the backup completes, folders beyond `--keep` (oldest first) are deleted.
 | `/etc/pve/` | Proxmox cluster config (storage, firewall, VMs, HA, SDN, …) |
 | `/root/.` | Root user config (incl. `.ssh`) |
 | `/var/lib/ceph/.` | Ceph configuration (if used) |
+| `/var/spool/cron/crontabs` | Per-user cron jobs created via `crontab -e` (not in `/etc/`) |
+
+Missing paths are silently skipped (tar runs with `--ignore-failed-read`), so you can list optional paths without breaking the run.
 
 ---
 

--- a/src/Corsinvest.ProxmoxVE.NodeProtect.Api/ProtectEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.NodeProtect.Api/ProtectEngine.cs
@@ -91,8 +91,9 @@ public class ProtectEngine(ILogger<ProtectEngine> logger)
         await sshClient.ConnectAsync(cancellationToken);
 
         var quotedPaths = string.Join(" ", paths.Select(ShellQuote));
-        // -f - streams the archive to stdout so we can pipe it over SSH without touching disk on the node
-        using var cmd = sshClient.CreateCommand($"tar --one-file-system -czPf - {quotedPaths}");
+        // -f - streams the archive to stdout so we can pipe it over SSH without touching disk on the node.
+        // --ignore-failed-read tolerates paths that don't exist on the node instead of failing the whole run.
+        using var cmd = sshClient.CreateCommand($"tar --one-file-system --ignore-failed-read -czPf - {quotedPaths}");
 
         logger.LogDebug("[{Node}] Executing: {Cmd}", node, cmd.CommandText);
 


### PR DESCRIPTION
## Summary
Fixes the case where listing an optional path in ` --paths ` would abort the whole backup when that path didn't exist on the node (e.g. ` /var/lib/ceph/. ` on a node without Ceph, or custom ` /root/scripts `).

Tar now runs with ` --ignore-failed-read `, so missing paths are silently skipped and the archive contains what is actually present on the node.

Also updated the README to document the new behaviour and list ` /var/spool/cron/crontabs ` in the suggested archive content table (per-user cron entries are not in ` /etc/ `).

## Test plan
- [ ] Backup with all existing paths → archive created as before
- [ ] Backup with one non-existent path in the list → archive created, no error
- [ ] Backup with all paths non-existent → archive empty (tar creates it but with no entries)